### PR TITLE
WIP: Remove hardcoded font

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -6,7 +6,6 @@ export const DEFAULT_CONTRACT_FILENAME = 'contract.html'
 export const DEFAULT_CONTRACT_TEMPLATE = `<h1>New Contract</h1>
 <p>Created on {{date}}. Start adding your contract content here.</p>`
 export const DEFAULT_PARAMS_FILENAME = 'params.toml'
-export const DEFAULT_PDF_FONT = 'Helvetica'
 export const DEFAULT_PDF_ENGINE = 'tectonic'
 export const DEFAULT_TEMPLATE_EXT = '.md'
 

--- a/src/shared/contract.ts
+++ b/src/shared/contract.ts
@@ -2,7 +2,7 @@ import { TomlReader } from '@sgarciac/bombadil'
 import * as Handlebars from 'handlebars'
 import * as tmp from 'tmp'
 import * as path from 'path'
-import { DEFAULT_TEXT_FILE_ENCODING, DEFAULT_PDF_FONT, DEFAULT_PDF_ENGINE, DEFAULT_TEMPLATE_EXT, DEFAULT_GIT_REPO_CACHE_PATH, RESERVED_TEMPLATE_VARS } from './constants'
+import { DEFAULT_TEXT_FILE_ENCODING, DEFAULT_PDF_ENGINE, DEFAULT_TEMPLATE_EXT, DEFAULT_GIT_REPO_CACHE_PATH, RESERVED_TEMPLATE_VARS } from './constants'
 import { isGitURL, GitURL } from './git-url'
 import { readFileAsync, writeFileAsync, spawnAsync, copyFileAsync, readdirAsync, fileExistsAsync, writeGMAsync, dirExistsAsync } from './async-io'
 import { DocumentCache, computeCacheFilename, computeContentHash } from './document-cache'
@@ -703,12 +703,9 @@ export class Contract {
   }
 
   private buildPandocArgs(inputFile: string, outputFile: string, style: any): string[] {
-    const font = 'font' in style ? style.font : DEFAULT_PDF_FONT
     const pdfEngine = 'pdf_engine' in style ? style.pdf_engine : DEFAULT_PDF_ENGINE
     return [
       inputFile,
-      '-V',
-      `mainfont="${font}"`,
       `--pdf-engine=${pdfEngine}`,
       '-o',
       outputFile,


### PR DESCRIPTION
I think it's best to just let pandoc use whatever font it defaults to.
This ensures that if pandoc works on the users machine for generating
PDFs, then it'll work to render our templates.

We can follow this up with changes to make the font configurable,
via #19, or some other means, to that users can specify Helvetica or
whatever else if they so choose.

This came up for me because contract compilation would fail due to not
having Helvetica installed.