### PR TITLE
Support pandoc defaults file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+* Remove `--style` flag from `compile` subcommand
+  ([#21](https://github.com/informalsystems/themis-contract/pull/21))
+* Add `--defaults` flag to `compile` command, allowing pass through of a pandoc
+  defaults file. ([#21](https://github.com/informalsystems/themis-contract/pull/21))
+* Add `init` subcommand for initializing user environment 
+  ([#21](https://github.com/informalsystems/themis-contract/pull/21))
+
 ## v0.1.6
 
 * Rename `neat-contract` to `themis-contract`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ To run this application, you will need:
   v12.15+)
 - [pandoc](https://pandoc.org/) (for transforming Markdown and HTML files to
   LaTeX)
+- [pandoc-crossref](https://pandoc.org/) (for section and figure referencing in
+  markdown templates)
 - [tectonic](https://tectonic-typesetting.github.io/en-US/) (for compiling LaTeX
   files to PDF)
 - [Keybase CLI](https://keybase.io/) (for cryptographically signing contracts)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ Once you have the requirements installed, simply:
 
 ## Usage
 
+## Initialization
+
+To initialize your user environment with default configurations, run
+
+```sh
+themis-contract init
+```
+
+If you ever with to reset the configurations, run
+
+```sh
+themis-contract init --reset
+```
+
 ### Identities
 
 In order to sign anything, you need to set up one or more **identities** for

--- a/README.md
+++ b/README.md
@@ -66,17 +66,21 @@ Once you have the requirements installed, simply:
 
 ## Initialization
 
-To initialize your user environment with default configurations, run
+To initialize your user environment with the default configurations, run
 
 ```sh
 themis-contract init
 ```
 
-If you ever with to reset the configurations, run
+This won't overwriting or any existing configurations.
+
+If you ever want to reset the configurations, run
 
 ```sh
 themis-contract init --reset
 ```
+
+This will overwrite any configurations, restoring them to their default values.
 
 ### Identities
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "/bin",
     "/lib",
     "/npm-shrinkwrap.json",
-    "/oclif.manifest.json"
+    "/oclif.manifest.json",
+    "/pandoc-defaults.json"
   ],
   "homepage": "https://github.com/informalsystems/themis-contract",
   "keywords": [

--- a/pandoc-defaults.yaml
+++ b/pandoc-defaults.yaml
@@ -1,0 +1,25 @@
+from: markdown+fenced_divs+bracketed_spans
+
+# Use if h1 headings are not clauses
+# shift-heading-levels-by: -1
+
+standalone: true
+self-contained: true
+
+# to get explicit sections divs based on relative heading positions
+section-divs: true
+
+# To get numbered html sections
+number-sections: true
+
+# Custom latex styles to append to the header
+# include-in-header: []
+
+# Transformations over the pandoc AST
+filters:
+  # See https://github.com/lierdakil/pandoc-crossref
+  - pandoc-crossref
+
+metadata:
+  # References to `#sec:foo` tags are rendered as "Section 1"
+  secPrefix: ["Section", "Sections"]

--- a/pandoc-defaults.yaml
+++ b/pandoc-defaults.yaml
@@ -1,18 +1,19 @@
 from: markdown+fenced_divs+bracketed_spans
 
-# Use if h1 headings are not clauses
+# Use if h1 headings should not be numbered sections
 # shift-heading-levels-by: -1
 
 standalone: true
 self-contained: true
 
-# to get explicit sections divs based on relative heading positions
+# Enables explicit sections divs based on relative heading positions
 section-divs: true
 
-# To get numbered html sections
+# Number sections
 number-sections: true
 
-# Custom latex styles to append to the header
+# Custom latex styles to append to the header,
+# each item in the list should be a file path
 # include-in-header: []
 
 # Transformations over the pandoc AST

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -36,7 +36,7 @@ install_for_macos() {
   fi
 
   echo "Installing requirements through Homebrew..."
-  brew install git node@12 pandoc tectonic graphicsmagick ghostscript || true
+  brew install git node@12 pandoc tectonic graphicsmagick ghostscript pandoc-crossref || true
   # Ensure our path is set up correctly to use the freshly installed NodeJS
   unixlike_add_path "/usr/local/opt/node@12/bin"
   export PATH="/usr/local/opt/node@12/bin:${PATH}"

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -1,8 +1,6 @@
 import { Command, flags } from '@oclif/command'
 import { Contract } from '../shared/contract'
-import { logger } from '../shared/logging'
-import { readFileAsync } from '../shared/async-io'
-import { DEFAULT_TEXT_FILE_ENCODING, templateCachePath, DEFAULT_PROFILE_PATH, gitRepoCachePath } from '../shared/constants'
+import { templateCachePath, DEFAULT_PROFILE_PATH, gitRepoCachePath, DEFAULT_PANDOC_DEFAULTS_FILE } from '../shared/constants'
 import { DocumentCache } from '../shared/document-cache'
 import { cliWrap } from '../shared/cli-helpers'
 
@@ -18,7 +16,7 @@ export default class Compile extends Command {
     help: flags.help({ char: 'h' }),
     output: flags.string({ char: 'o', default: './contract.pdf', description: 'where to write the output contract PDF' }),
     profile: flags.string({ char: 'p', default: DEFAULT_PROFILE_PATH, description: 'your local profile path (for managing identities, templates, etc.)' }),
-    style: flags.string({ char: 's', description: 'an optional style file to specify the font and PDF engine to use when rendering the PDF' }),
+    defaults: flags.string({ char: 'd', default: DEFAULT_PANDOC_DEFAULTS_FILE, description: 'a custom pandoc defaults file configuring pandoc compilation of templates' }),
     verbose: flags.boolean({ char: 'v', default: false, description: 'increase output logging verbosity to DEBUG level' }),
     verify: flags.boolean({ description: 'verify the contract before compiling it' }),
   }
@@ -30,11 +28,6 @@ export default class Compile extends Command {
   async run() {
     const { args, flags } = this.parse(Compile)
     await cliWrap(this, flags.verbose, async () => {
-      let style: any = {}
-      if (flags.style) {
-        style = await readFileAsync(flags.style, { encoding: DEFAULT_TEXT_FILE_ENCODING })
-        logger.debug(`Loaded style: ${style}`)
-      }
       // configure our template cache
       const cache = await DocumentCache.init(templateCachePath(flags.profile))
       const contract = await Contract.fromFile(args.path, {
@@ -42,7 +35,7 @@ export default class Compile extends Command {
         cache: cache,
       })
       await contract.compile(flags.output, {
-        style: style,
+        defaults: flags.defaults,
         verify: flags.verify,
       })
     })

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,28 @@
+import * as init from '../shared/init'
+import { Command, flags } from '@oclif/command'
+import { DEFAULT_PROFILE_PATH } from '../shared/constants'
+import { cliWrap } from '../shared/cli-helpers'
+
+export default class Init extends Command {
+  static description = 'initialize the user environment'
+
+  static examples = [
+    '$ themis-contract init',
+    '$ themis-contract init --reset',
+  ]
+
+  static flags = {
+    help: flags.help({ char: 'h' }),
+    reset: flags.boolean({default: false, description: 'reset all initialized configurations to the default state' }),
+    profile: flags.string({ char: 'p', default: DEFAULT_PROFILE_PATH, description: 'your local profile path (for managing identities, templates, etc.)' }),
+    verbose: flags.boolean({ char: 'v', default: false, description: 'increase output logging verbosity to DEBUG level' }),
+  }
+
+  async run() {
+    const { flags } = this.parse(Init)
+    await cliWrap(this, flags.verbose, async () => {
+      // configure our template cache
+      await init.run(flags.profile, flags.reset)
+    })
+  }
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -6,12 +6,11 @@ export const DEFAULT_CONTRACT_FILENAME = 'contract.html'
 export const DEFAULT_CONTRACT_TEMPLATE = `<h1>New Contract</h1>
 <p>Created on {{date}}. Start adding your contract content here.</p>`
 export const DEFAULT_PARAMS_FILENAME = 'params.toml'
-export const DEFAULT_PDF_FONT = 'Helvetica'
-export const DEFAULT_PDF_ENGINE = 'tectonic'
 export const DEFAULT_TEMPLATE_EXT = '.md'
 
 export const HOMEDIR = os.homedir()
 export const DEFAULT_PROFILE_PATH = path.join(HOMEDIR, '.themis', 'contract')
+export const DEFAULT_PANDOC_DEFAULTS_FILE = path.join(HOMEDIR, '.themis', 'pandoc-defaults.yaml')
 
 // We store cached templates in this folder, where the names of the files are
 // MD5 hashes (in hex) of their source paths. This allows us to track many

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -14,6 +14,8 @@ export const DEFAULT_PROFILE_PATH = path.join(HOMEDIR, '.themis', 'contract')
 export const DEFAULT_PANDOC_DEFAULTS_FILE =
   path.join(DEFAULT_PROFILE_PATH, PANDOC_DEFAULTS_FILE_NAME)
 
+export const INSTALLATION_DIR = path.join(__dirname, '..', '..')
+
 // We store cached templates in this folder, where the names of the files are
 // MD5 hashes (in hex) of their source paths. This allows us to track many
 // different sources' templates in a single flat folder.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -7,10 +7,12 @@ export const DEFAULT_CONTRACT_TEMPLATE = `<h1>New Contract</h1>
 <p>Created on {{date}}. Start adding your contract content here.</p>`
 export const DEFAULT_PARAMS_FILENAME = 'params.toml'
 export const DEFAULT_TEMPLATE_EXT = '.md'
+export const PANDOC_DEFAULTS_FILE_NAME = 'pandoc-defaults.yaml'
 
 export const HOMEDIR = os.homedir()
 export const DEFAULT_PROFILE_PATH = path.join(HOMEDIR, '.themis', 'contract')
-export const DEFAULT_PANDOC_DEFAULTS_FILE = path.join(HOMEDIR, '.themis', 'pandoc-defaults.yaml')
+export const DEFAULT_PANDOC_DEFAULTS_FILE =
+  path.join(DEFAULT_PROFILE_PATH, PANDOC_DEFAULTS_FILE_NAME)
 
 // We store cached templates in this folder, where the names of the files are
 // MD5 hashes (in hex) of their source paths. This allows us to track many

--- a/src/shared/init.ts
+++ b/src/shared/init.ts
@@ -1,0 +1,38 @@
+import * as path from 'path'
+import {INSTALLATION_DIR, PANDOC_DEFAULTS_FILE_NAME } from '../shared/constants'
+import { copyFileAsync, fileExistsAsync } from '../shared/async-io'
+import { logger } from '../shared/logging'
+
+export const PANDOC_DEFAULTS_SRC = path.join(INSTALLATION_DIR, PANDOC_DEFAULTS_FILE_NAME)
+
+// Workaround for inability to use variables as keys in object literal
+const buildFileDict: () => Record<string, string> = () => {
+  const r: Record<string, string> = {}
+  r[PANDOC_DEFAULTS_SRC] = PANDOC_DEFAULTS_FILE_NAME
+  return r
+}
+
+// Mapping source files to destinations, given relative to the users profile
+export const FILES_TO_INSTALL = buildFileDict()
+
+/**
+ * Initializes the user's system with default configurations.
+ *
+ * @param {string} profile The directory in which configurations and resources
+ * are stored.
+ *
+ * @param {boolean} reset Whether or not existing configurations should be
+ * reinitialized. If `false`, no existing configurations values will be
+ * altered.
+ */
+export const run = async (profile: string, reset: boolean) => {
+  for (const [src, name] of Object.entries(FILES_TO_INSTALL)) {
+    const dest = path.join(profile, name)
+    if (await fileExistsAsync(dest) && !reset) {
+      logger.debug(`skipping initialization of ${dest}: file already exists`)
+    } else {
+      await copyFileAsync(src, dest)
+      logger.debug(`${reset ? 're-' : ''}initialized ${dest}`)
+    }
+  }
+}

--- a/test/shared/init.test.ts
+++ b/test/shared/init.test.ts
@@ -1,0 +1,66 @@
+import * as assert from 'assert'
+import * as init from '../../src/shared/init'
+import * as tmp from 'tmp'
+import * as path from 'path'
+import { fileExistsAsync, writeFileAsync, readFileAsync } from '../../src/shared/async-io'
+
+const assertFileExists = async (file: string) => {
+  assert.strictEqual(await fileExistsAsync(file), true, `file ${file} was not created`)
+}
+
+const writeDummyFiles  = async (dir: string, content: string) => {
+  const files: string[] = []
+  for (const e of Object.entries(init.FILES_TO_INSTALL)) {
+    const dest = path.join(dir, e[1])
+    await writeFileAsync(dest, content)
+    files.push(dest)
+  }
+  return files
+}
+
+describe('Init', () => {
+  describe('#run', () => {
+    it('should install the expected resources', async () => {
+      const tmpDir = tmp.dirSync()
+      await init.run(tmpDir.name, false)
+
+      for (const e of Object.entries(init.FILES_TO_INSTALL)) {
+        await assertFileExists(path.join(tmpDir.name, e[1]))
+      }
+
+      tmpDir.removeCallback()
+    })
+
+    it('should not overwrite existing configurations', async () => {
+      const dummyContent = 'SOME CONTENT'
+      const tmpDir = tmp.dirSync()
+
+      const files = await writeDummyFiles(tmpDir.name, dummyContent)
+      await init.run(tmpDir.name, false)
+
+      // Ensure the file content HAS NOT changed
+      for (let i = 0; i < files.length; i++) {
+        const content = (await readFileAsync(files[i])).toString()
+        assert.strictEqual(dummyContent, content, `Expected ${dummyContent} but found ${content}`)
+      }
+
+      tmpDir.removeCallback()
+    })
+
+    it('should overwrite existing configurations when reset flag is true', async () => {
+      const dummyContent = 'SOME CONTENT'
+      const tmpDir = tmp.dirSync()
+
+      const files = await writeDummyFiles(tmpDir.name, dummyContent)
+      await init.run(tmpDir.name, true)
+
+      // Ensure the file content HAS changed
+      for (let i = 0; i < files.length; i++) {
+        const content = (await readFileAsync(files[i])).toString()
+        assert.notStrictEqual(dummyContent, content, `Found unexpected ${dummyContent}`)
+      }
+
+      tmpDir.removeCallback()
+    })
+  })
+})


### PR DESCRIPTION
This adds support for specifying a pandoc defaults file to configure the
pandoc rendering. It replaces hardcoded values and configuration via the
`--styles` flag with the defaults file.

Closes #19
Supersedes #20