### PR TITLE
Fix `TypeError: string "" is not a function`

### DIFF
--- a/src/shared/template-helpers.ts
+++ b/src/shared/template-helpers.ts
@@ -16,7 +16,10 @@ const trackVariable = (tracker: Map<string, any>, path: string[], varName: strin
 const makeVariableTrackerProxy = (parentObj: object, parents: string[], trackedVars: Map<string, any>): object => {
   return new Proxy(parentObj, {
     get: (target, name) => {
-      if (typeof name === 'symbol' || name === 'toHTML') {
+      if (typeof name === 'symbol') {
+        return ''
+      }
+      if (name === 'toHTML') {
         return (): string => ''
       }
       const varName = String(name)

--- a/src/shared/template-helpers.ts
+++ b/src/shared/template-helpers.ts
@@ -33,7 +33,16 @@ const makeVariableTrackerProxy = (parentObj: object, parents: string[], trackedV
 export const extractHandlebarsTemplateVariables = (templateSrc: string): Map<string, any> => {
   const template = Handlebars.compile(templateSrc)
   const vars = new Map<string, any>()
-  template(makeVariableTrackerProxy({}, [], vars), {allowProtoPropertiesByDefault: true})
+  try {
+    template(makeVariableTrackerProxy({}, [], vars), {allowProtoPropertiesByDefault: true})
+  } catch (error) {
+    if (error instanceof TypeError) {
+      const msg = 'Unable to extract handlebars variables. Did you mean to specify a different template system?'
+      throw new Error(msg)
+    } else {
+      throw error
+    }
+  }
   return vars
 }
 

--- a/src/shared/template-helpers.ts
+++ b/src/shared/template-helpers.ts
@@ -16,10 +16,7 @@ const trackVariable = (tracker: Map<string, any>, path: string[], varName: strin
 const makeVariableTrackerProxy = (parentObj: object, parents: string[], trackedVars: Map<string, any>): object => {
   return new Proxy(parentObj, {
     get: (target, name) => {
-      if (typeof name === 'symbol') {
-        return ''
-      }
-      if (name === 'toHTML') {
+      if (typeof name === 'symbol' || name === 'toHTML') {
         return (): string => ''
       }
       const varName = String(name)


### PR DESCRIPTION
Fixes #28 

Or, I should say, it *may* fix 28. I don't understand what the return value of this method gets used for, but combing branches to just always return a thunk is producing the expected result.