### PR TITLE
Set the barcode height to 15mm

### DIFF
--- a/src/shared/barcode-helpers.ts
+++ b/src/shared/barcode-helpers.ts
@@ -17,6 +17,7 @@ export const generatePDF417 = async (content: string): Promise<Buffer> => {
       bcid: 'pdf417',
       text: content,
       backgroundcolor: 'ffffff',
+      height: 15,
     }, (err, png) => {
       if (err) {
         reject(err)


### PR DESCRIPTION
This makes for nicer looking signatures, imo, and uses far less
realestate on a page.

Here's what it looks like:

![2020-05-18-120456_1303x510_scrot](https://user-images.githubusercontent.com/19820422/82234771-d4a6b900-98ff-11ea-8f5e-425db3ac6b97.png)
