### PR TITLE
Adds support for includes files to tweak latex

### DIFF
--- a/header-includes.tex
+++ b/header-includes.tex
@@ -1,0 +1,5 @@
+%% Don't add visible rule lines to tables
+%% helpful for styling since we use tables for signature boxes
+\def\toprule{}
+\def\bottomrule{}
+\def\midrule{}

--- a/include-before.tex
+++ b/include-before.tex
@@ -1,0 +1,4 @@
+%% Reduces the amount of space between the title headings and the
+%% start of the document content
+\thispagestyle{empty}
+\vspace*{-3em}

--- a/pandoc-defaults.yaml
+++ b/pandoc-defaults.yaml
@@ -12,9 +12,10 @@ section-divs: true
 # Number sections
 number-sections: true
 
-# Custom latex styles to append to the header,
+# Custom latex styles to add to the template
 # each item in the list should be a file path
-# include-in-header: []
+include-in-header: ["header-includes.tex"]
+include-before-body: ["include-before.tex"]
 
 # Transformations over the pandoc AST
 filters:

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -7,7 +7,10 @@ export const DEFAULT_CONTRACT_TEMPLATE = `<h1>New Contract</h1>
 <p>Created on {{date}}. Start adding your contract content here.</p>`
 export const DEFAULT_PARAMS_FILENAME = 'params.toml'
 export const DEFAULT_TEMPLATE_EXT = '.md'
+
 export const PANDOC_DEFAULTS_FILE_NAME = 'pandoc-defaults.yaml'
+export const PANDOC_HEADER_INCLUDES_FILE_NAME = 'header-includes.tex'
+export const PANDOC_INCLUDE_BEFORE_FILE_NAME = 'include-before.tex'
 
 export const HOMEDIR = os.homedir()
 export const DEFAULT_PROFILE_PATH = path.join(HOMEDIR, '.themis', 'contract')

--- a/src/shared/contract.ts
+++ b/src/shared/contract.ts
@@ -2,7 +2,7 @@ import { TomlReader } from '@sgarciac/bombadil'
 import * as Handlebars from 'handlebars'
 import * as tmp from 'tmp'
 import * as path from 'path'
-import { DEFAULT_TEXT_FILE_ENCODING, DEFAULT_TEMPLATE_EXT, DEFAULT_GIT_REPO_CACHE_PATH, RESERVED_TEMPLATE_VARS } from './constants'
+import { DEFAULT_TEXT_FILE_ENCODING, DEFAULT_TEMPLATE_EXT, DEFAULT_GIT_REPO_CACHE_PATH, RESERVED_TEMPLATE_VARS, DEFAULT_PROFILE_PATH } from './constants'
 import { isGitURL, GitURL } from './git-url'
 import { readFileAsync, writeFileAsync, spawnAsync, copyFileAsync, readdirAsync, fileExistsAsync, writeGMAsync, dirExistsAsync } from './async-io'
 import { DocumentCache, computeCacheFilename, computeContentHash } from './document-cache'
@@ -710,7 +710,12 @@ export class Contract {
   }
 
   private buildPandocArgs(inputFile: string, outputFile: string, defaults?: string): string[] {
-    const baseArgs = [inputFile, '-o', outputFile]
+    // See https://pandoc.org/MANUAL.html#options
+    // `resource-path` tells pandoc where to look for stuff like the defaults
+    // file or template overrides
+    const resourcePathLocations = ['.', DEFAULT_PROFILE_PATH]
+    const resourcePath = resourcePathLocations.join(':')
+    const baseArgs = [inputFile, '-o', outputFile, '--resource-path', resourcePath]
     let defaultsFlag: string[] = []
     if (defaults) {
       defaultsFlag = ['--defaults', defaults]

--- a/src/shared/init.ts
+++ b/src/shared/init.ts
@@ -1,14 +1,20 @@
 import * as path from 'path'
-import {INSTALLATION_DIR, PANDOC_DEFAULTS_FILE_NAME } from '../shared/constants'
+import {INSTALLATION_DIR, PANDOC_DEFAULTS_FILE_NAME, PANDOC_HEADER_INCLUDES_FILE_NAME, PANDOC_INCLUDE_BEFORE_FILE_NAME } from '../shared/constants'
 import { copyFileAsync, fileExistsAsync, ensurePath } from '../shared/async-io'
 import { logger } from '../shared/logging'
 
 export const PANDOC_DEFAULTS_SRC = path.join(INSTALLATION_DIR, PANDOC_DEFAULTS_FILE_NAME)
+export const PANDOC_HEADER_INCLUDES_SRC =
+  path.join(INSTALLATION_DIR, PANDOC_HEADER_INCLUDES_FILE_NAME)
+export const PANDOC_INCLUDE_BEFORE_SRC =
+  path.join(INSTALLATION_DIR, PANDOC_INCLUDE_BEFORE_FILE_NAME)
 
 // Workaround for inability to use variables as keys in object literal
 const buildFileDict: () => Record<string, string> = () => {
   const r: Record<string, string> = {}
   r[PANDOC_DEFAULTS_SRC] = PANDOC_DEFAULTS_FILE_NAME
+  r[PANDOC_HEADER_INCLUDES_SRC] = PANDOC_HEADER_INCLUDES_FILE_NAME
+  r[PANDOC_INCLUDE_BEFORE_SRC] = PANDOC_INCLUDE_BEFORE_FILE_NAME
   return r
 }
 


### PR DESCRIPTION
This change adds two default config files for adding latex styling to
the header of a template and prepending before the content. This won't
affect compiling directly from latex, since we use tectonic rather than
pandoc for this.

This also uses the new configurability to produce nicer formatting of
from markdown templates.