### PR TITLE
Ensure profile path exists prior to running init logic

### DIFF
--- a/src/shared/init.ts
+++ b/src/shared/init.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import {INSTALLATION_DIR, PANDOC_DEFAULTS_FILE_NAME } from '../shared/constants'
-import { copyFileAsync, fileExistsAsync } from '../shared/async-io'
+import { copyFileAsync, fileExistsAsync, ensurePath } from '../shared/async-io'
 import { logger } from '../shared/logging'
 
 export const PANDOC_DEFAULTS_SRC = path.join(INSTALLATION_DIR, PANDOC_DEFAULTS_FILE_NAME)
@@ -26,6 +26,7 @@ export const FILES_TO_INSTALL = buildFileDict()
  * altered.
  */
 export const run = async (profile: string, reset: boolean) => {
+  await ensurePath(profile)
   for (const [src, name] of Object.entries(FILES_TO_INSTALL)) {
     const dest = path.join(profile, name)
     if (await fileExistsAsync(dest) && !reset) {


### PR DESCRIPTION
Right now, if `~/.themis` does not exist, running `themis-contract init` fails with:

```
2020-05-19 15:32:08 error ENOENT: no such file or directory, copyfile '/Users/user/.config/yarn/global/node_modules/themis-contract/pandoc-defaults.yaml' -> '/Users/user/.themis/contract/pandoc-defaults.yaml'
```

This PR fixes the problem by creating the profile folder (`~/.themis`) first.