### PR TITLE
Add release workflow for MacOS and Linux

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,10 @@
-name: Go
+name: Build and Test
 
 on:
   push:
-    branches: [ "prototype/v2" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "prototype/v2" ]
+    branches: [ "master" ]
 
 jobs:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,124 @@
+name: Release
+
+on:
+  push:
+    tags: [ "v*" ]
+
+jobs:
+
+  build-linux:
+    name: Build for Linux
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Go 1.14+
+        uses: actions/setup-go@v2
+        with:
+          go-version: "^1.14"
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+
+      - name: Get statik
+        run: |
+          go get github.com/rakyll/statik
+
+      - name: Build
+        run: make
+
+      - name: Test
+        run: make test
+
+      - name: Upload Linux build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: bin-linux
+          path: build/themis-contract
+
+  build-macos:
+    name: Build for MacOS
+    runs-on: macos-latest
+    steps:
+
+      - name: Set up Go 1.14+
+        uses: actions/setup-go@v2
+        with:
+          go-version: "^1.14"
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+
+      - name: Get statik
+        run: |
+          go get github.com/rakyll/statik
+
+      - name: Build
+        run: make
+
+      - name: Test
+        run: make test
+
+      - name: Upload MacOS build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: bin-macos
+          path: build/themis-contract
+
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    needs: [ "build-linux", "build-macos" ]
+    steps:
+
+      - name: Download Linux Artifact
+        uses: actions/download-artifact@v2
+        with:
+          - name: bin-linux
+            path: ./themis-contract-linux
+
+      - name: Download MacOS Artifact
+        uses: actions/download-artifact@v2
+        with:
+          - name: bin-macos
+            path: ./themis-contract-macos
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Linux binary for release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./themis-contract-linux
+          asset_name: themis-contract-linux
+          asset_content_type: application/octet-stream
+
+      - name: Upload MacOS binary for release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./themis-contract-macos
+          asset_name: themis-contract-macos
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
This adds GitHub Actions-based workflows for:

* Building and testing on any pushes or PRs to `master`
* Building and releasing executables for Linux (built from Ubuntu) and MacOS on any new tags of the format `v*`