### PR TITLE
Fix signatories bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.2
+
+* Fix a critical bug that prevents signing of a contract
+  ([\#70](https://github.com/informalsystems/themis-contract/pull/70)).
+
 ## v0.2.1
 
 * Fix a critical compilation bug that prevented signature image details from


### PR DESCRIPTION
Without this fix, an error will be thrown every time we try to sign a contract due to the `updateContractSignatories` method not being able to interpret the data type of the "signatories" entry in the supplied parameters. It seems a little extraneous to do all these type checks, but it appears it's necessary.