### PR TITLE
Fix minor spelling mistakes caused by IDE in auto-rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+* Fix some minor spelling mistakes in the CLI help
+  ([\#71](https://github.com/informalsystems/themis-contract/pull/71)).
+
 ## v0.2.2
 
 * Fix a critical bug that prevents signing of a contract

--- a/cmd/themis-contract/profile.go
+++ b/cmd/themis-contract/profile.go
@@ -20,7 +20,7 @@ func profileCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "profile",
 		Aliases: []string{"profiles"},
-		Short:   "ActiveProfile management",
+		Short:   "Profile management",
 	}
 	cmd.AddCommand(
 		profileListCmd(),

--- a/pkg/themis-contract/profile.go
+++ b/pkg/themis-contract/profile.go
@@ -32,7 +32,7 @@ type ProfileDB struct {
 	profilesPath  string              // The path to the root of where to find all of the profiles.
 }
 
-// ActiveProfile is a way of naming and differentiating between rendering
+// Profile is a way of naming and differentiating between rendering
 // configurations used when rendering contracts.
 type Profile struct {
 	Name          string             `json:"name"`                   // A short, descriptive name for the profile.


### PR DESCRIPTION
My IDE automatically renamed all the `Profile` instances everywhere to `ActiveProfile`, including in strings. This PR reverts that minor mistake.